### PR TITLE
Add support for custom TET tuning systems

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -48,6 +48,8 @@ import {
   ROOT_DEFAULT,
   CAPO_DEFAULT,
   DISPLAY_DEFAULTS,
+  CUSTOM_TET_MIN,
+  CUSTOM_TET_MAX,
 } from "@/lib/config/appDefaults";
 
 import { DEFAULT_TUNINGS, PRESET_TUNINGS } from "@/lib/presets/presetState";
@@ -86,8 +88,17 @@ import { LABEL_VALUES } from "@/hooks/useLabels";
 
 import { makeImmerSetters } from "@/utils/makeImmerSetters";
 
+const clampCustomDivisor = (value) => {
+  if (!Number.isFinite(value)) return CUSTOM_TET_MIN;
+  const rounded = Math.round(value);
+  if (rounded < CUSTOM_TET_MIN) return CUSTOM_TET_MIN;
+  if (rounded > CUSTOM_TET_MAX) return CUSTOM_TET_MAX;
+  return rounded;
+};
+
 export default function App() {
   const defaultSystem = TUNINGS[SYSTEM_DEFAULT];
+  const defaultDivisions = clampCustomDivisor(defaultSystem?.divisions ?? 12);
 
   // System selection
   const [systemId, setSystemId] = useState(SYSTEM_DEFAULT);
@@ -97,11 +108,11 @@ export default function App() {
 
   const sanitizedCustomDivisor = useMemo(() => {
     const parsed = Number(customDivisor);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      return Number(defaultSystem?.divisions ?? 12);
+    if (!Number.isFinite(parsed)) {
+      return defaultDivisions;
     }
-    return Math.max(1, Math.round(parsed));
-  }, [customDivisor, defaultSystem]);
+    return clampCustomDivisor(parsed);
+  }, [customDivisor, defaultDivisions]);
 
   const customSystem = useMemo(() => {
     const divisions = sanitizedCustomDivisor;

--- a/src/components/UI/TuningSystemSelector.jsx
+++ b/src/components/UI/TuningSystemSelector.jsx
@@ -2,7 +2,29 @@ import React from "react";
 import { dequal } from "dequal";
 import Section from "@/components/UI/Section";
 
-function TuningSystemSelector({ systemId, setSystemId, systems }) {
+const CUSTOM_SYSTEM_ID = "custom";
+
+function TuningSystemSelector({
+  systemId,
+  setSystemId,
+  systems,
+  customDivisor,
+  onCustomDivisorChange,
+}) {
+  const handleCustomDivisorChange = (event) => {
+    const { value } = event.target;
+    if (value === "") {
+      onCustomDivisorChange("");
+      return;
+    }
+
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) return;
+
+    const sanitized = Math.max(1, Math.round(parsed));
+    onCustomDivisorChange(String(sanitized));
+  };
+
   return (
     <Section title="Tuning System" size="sm">
       <div className="field">
@@ -18,14 +40,35 @@ function TuningSystemSelector({ systemId, setSystemId, systems }) {
               {id}
             </option>
           ))}
+          <option value={CUSTOM_SYSTEM_ID}>
+            {customDivisor ? `Custom (${customDivisor}-TET)` : "Custom"}
+          </option>
         </select>
       </div>
+      {systemId === CUSTOM_SYSTEM_ID ? (
+        <div className="field">
+          <span>Divisions</span>
+          <input
+            id="custom-tuning-divisor"
+            type="number"
+            min={1}
+            step={1}
+            inputMode="numeric"
+            value={customDivisor ?? ""}
+            onChange={handleCustomDivisorChange}
+          />
+        </div>
+      ) : null}
     </Section>
   );
 }
 
 function pick(p) {
-  return { systemId: p.systemId, systems: p.systems };
+  return {
+    systemId: p.systemId,
+    systems: p.systems,
+    customDivisor: p.customDivisor,
+  };
 }
 export default React.memo(TuningSystemSelector, (a, b) =>
   dequal(pick(a), pick(b)),

--- a/src/hooks/usePitchMapping.js
+++ b/src/hooks/usePitchMapping.js
@@ -1,4 +1,5 @@
 import { useMemo, useCallback } from "react";
+import { TUNINGS } from "@/lib/theory/tuning";
 
 /**
  * Maps between note-name spellings and pitch classes for a given tuning system.
@@ -9,10 +10,26 @@ import { useMemo, useCallback } from "react";
 export function usePitchMapping(system, accidental) {
   const nameToPc = useMemo(() => {
     const map = new Map();
-    for (let pc = 0; pc < system.divisions; pc++) {
+    const { divisions } = system;
+
+    for (let pc = 0; pc < divisions; pc++) {
       map.set(system.nameForPc(pc, "sharp"), pc);
       map.set(system.nameForPc(pc, "flat"), pc);
     }
+
+    const twelveTet = TUNINGS?.["12-TET"];
+    if (twelveTet && Number.isFinite(divisions) && divisions > 0) {
+      const scaleFactor = divisions / 12;
+      for (let pc12 = 0; pc12 < 12; pc12++) {
+        const approxPc = Math.round(pc12 * scaleFactor) % divisions;
+        const sharpName = twelveTet.nameForPc(pc12, "sharp");
+        if (!map.has(sharpName)) map.set(sharpName, approxPc);
+
+        const flatName = twelveTet.nameForPc(pc12, "flat");
+        if (!map.has(flatName)) map.set(flatName, approxPc);
+      }
+    }
+
     return map;
   }, [system]);
 

--- a/src/hooks/useTuningIO.js
+++ b/src/hooks/useTuningIO.js
@@ -35,7 +35,7 @@ const TuningPackArraySchema = v.array(TuningPackSchema);
    Hook
 ========================= */
 
-export function useTuningIO({ systemId, strings, TUNINGS }) {
+export function useTuningIO({ systemId, system, strings }) {
   // Persist array of custom packs directly
   const [customTunings, setCustomTunings] = useLocalStorage(
     STORAGE_KEYS.CUSTOM_TUNINGS,
@@ -45,7 +45,7 @@ export function useTuningIO({ systemId, strings, TUNINGS }) {
   // ----- Export current tuning as a pack (pure) -----
   const getCurrentTuningPack = useCallback(
     (tuning, stringMeta = null) => {
-      const sys = TUNINGS[systemId];
+      const edo = Number(system?.divisions) || 12;
       const stringsArr = tuning.map((n, i) => {
         const meta = stringMeta?.find((m) => m.index === i) || {};
         return {
@@ -62,12 +62,12 @@ export function useTuningIO({ systemId, strings, TUNINGS }) {
       return {
         version: 2,
         name: `${systemId} ${strings}-string`,
-        system: { edo: sys.divisions },
+        system: { edo },
         tuning: { strings: stringsArr },
         meta: stringMeta ? { stringMeta } : {},
       };
     },
-    [systemId, strings, TUNINGS],
+    [systemId, strings, system],
   );
 
   // ----- Export all custom tunings (pure) -----

--- a/src/lib/config/appDefaults.ts
+++ b/src/lib/config/appDefaults.ts
@@ -13,6 +13,9 @@ export const FRETS_MAX = 30;
 export const STR_FACTORY = 6;
 export const FRETS_FACTORY = 24;
 
+export const CUSTOM_TET_MIN = 2;
+export const CUSTOM_TET_MAX = 96;
+
 export function getFactoryFrets(edo: number): number {
   if (!Number.isFinite(edo) || edo <= 0) return FRETS_FACTORY;
   if (edo === 12) return FRETS_FACTORY;


### PR DESCRIPTION
## Summary
- add a Custom option to the tuning selector with an input for the desired TET divisor
- derive a memoized tuning system for custom divisors, reuse it across hooks, and stabilize reset keys with an effective system id
- update tuning export helpers to rely on the provided system object so custom systems serialize correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f49ef956d88330a8bf951b7fadaa80