### PR TITLE
Align control panel class names and adopt clsx

### DIFF
--- a/src/components/UI/ChordBuilder.jsx
+++ b/src/components/UI/ChordBuilder.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import Section from "@/components/UI/Section";
 import { CHORD_TYPES, CHORD_LABELS } from "@/lib/theory/chords";
 import { FiRotateCcw } from "react-icons/fi";
@@ -26,7 +27,7 @@ function ChordBuilder({
 
   return (
     <Section title="Chord Builder" size="sm">
-      <div className="control-panel chord-controls">
+      <div className={clsx("control-panel", "chord-controls")}>
         <div className="grid2">
           <div className="field">
             <span>Root</span>

--- a/src/components/UI/DisplayControls.jsx
+++ b/src/components/UI/DisplayControls.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import Section from "@/components/UI/Section";
 import { LABEL_OPTIONS } from "@/hooks/useLabels";
 import { MICRO_LABEL_STYLES } from "@/utils/fretLabels";
@@ -60,7 +61,7 @@ function DisplayControls({
 }) {
   return (
     <Section title="Display">
-      <div className="control-panel display-controls">
+      <div className={clsx("control-panel", "display-controls")}>
         <div className="group" role="region" aria-label="Notation">
           <div className="field">
             <span>Accidentals</span>

--- a/src/components/UI/ExportControls.jsx
+++ b/src/components/UI/ExportControls.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useMemo } from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import Section from "@/components/UI/Section";
 import { toast } from "react-hot-toast";
 
@@ -101,7 +102,7 @@ function ExportControls({
 
   return (
     <Section title="Export / Import">
-      <div className="control-panel export-controls">
+      <div className={clsx("control-panel", "export-controls")}>
         <div className="row">
           <button type="button" className="btn" onClick={doDownloadPNG}>
             Export PNG

--- a/src/components/UI/InstrumentControls.jsx
+++ b/src/components/UI/InstrumentControls.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import Section from "@/components/UI/Section";
 import {
   STR_MIN,
@@ -142,7 +143,7 @@ function InstrumentControls({
 
   return (
     <Section title="Instrument">
-      <div className="instrument">
+      <div className={clsx("control-panel", "instrument")}>
         <div className="row-2">
           {/* Strings */}
           <div className="field">
@@ -164,7 +165,7 @@ function InstrumentControls({
             />
             <small
               id="strings-help"
-              className={`help-text${stringsErr ? " help-text--error" : ""}`}
+              className={clsx("help-text", { "help-text--error": stringsErr })}
             >
               {stringsErr || `Allowed range: ${STR_MIN}–${STR_MAX}`}
             </small>
@@ -190,7 +191,7 @@ function InstrumentControls({
             />
             <small
               id="frets-help"
-              className={`help-text${fretsErr ? " help-text--error" : ""}`}
+              className={clsx("help-text", { "help-text--error": fretsErr })}
             >
               {fretsErr || `Allowed range: ${FRETS_MIN}–${FRETS_MAX}`}
             </small>

--- a/src/components/UI/ScaleControls.jsx
+++ b/src/components/UI/ScaleControls.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import { FiShuffle, FiRotateCcw } from "react-icons/fi";
 import Section from "@/components/UI/Section";
 
@@ -32,7 +33,7 @@ function ScaleControls({
 
   return (
     <Section title="Scale" size="sm">
-      <div className="scale-controls grid2">
+      <div className={clsx("control-panel", "scale-controls", "grid2")}>
         <div className="field">
           <span>Root</span>
           <select

--- a/src/components/UI/TuningSystemSelector.jsx
+++ b/src/components/UI/TuningSystemSelector.jsx
@@ -1,24 +1,27 @@
 import React from "react";
 import { dequal } from "dequal";
+import clsx from "clsx";
 import Section from "@/components/UI/Section";
 
 function TuningSystemSelector({ systemId, setSystemId, systems }) {
   return (
     <Section title="Tuning System" size="sm">
-      <div className="field">
-        <span>System</span>
-        <select
-          id="system"
-          name="system"
-          value={systemId}
-          onChange={(e) => setSystemId(e.target.value)}
-        >
-          {Object.keys(systems).map((id) => (
-            <option key={id} value={id}>
-              {id}
-            </option>
-          ))}
-        </select>
+      <div className={clsx("control-panel", "tuning-system-controls")}>
+        <div className="field">
+          <span>System</span>
+          <select
+            id="system"
+            name="system"
+            value={systemId}
+            onChange={(e) => setSystemId(e.target.value)}
+          >
+            {Object.keys(systems).map((id) => (
+              <option key={id} value={id}>
+                {id}
+              </option>
+            ))}
+          </select>
+        </div>
       </div>
     </Section>
   );


### PR DESCRIPTION
## Summary
- wrap every control section in the shared `control-panel` class while preserving existing layout-specific hooks
- migrate conditional class logic to `clsx` for clarity and consistency
- ensure tuning system and instrument helpers share the same status messaging styles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68f654ff31f48330a24a90f5df9be27e