### PR TITLE
Promote string fretStyle to board meta

### DIFF
--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -165,17 +165,16 @@ export default function App() {
     tuning,
     setTuning,
     presetMap,
-    presetMetaMap,
     presetNames,
     saveDefault,
     savedExists,
+    savedMeta,
     defaultForCount,
   } = useDefaultTuning({
     systemId,
     strings,
     DEFAULT_TUNINGS,
     PRESET_TUNINGS,
-    PRESET_TUNING_META,
   });
 
   const [stringMeta, setStringMeta] = useState(null);
@@ -257,8 +256,9 @@ export default function App() {
     queuePresetByName,
   } = useMergedPresets({
     presetMap,
-    presetMetaMap,
     presetNames,
+    presetMetaSource: PRESET_TUNING_META,
+    savedMeta,
     customTunings,
     setTuning,
     setStringMeta,

--- a/src/hooks/useDefaultTuning.js
+++ b/src/hooks/useDefaultTuning.js
@@ -32,7 +32,6 @@ export function useDefaultTuning({
   strings,
   DEFAULT_TUNINGS,
   PRESET_TUNINGS,
-  PRESET_TUNING_META = {},
 }) {
   const storeKey = keyOf(systemId, strings);
 
@@ -93,28 +92,6 @@ export function useDefaultTuning({
     }
     return m;
   }, [factory, savedExists, saved, systemId, strings, PRESET_TUNINGS]);
-
-  const presetMetaMap = useMemo(() => {
-    const metaForGroup = PRESET_TUNING_META?.[systemId]?.[strings] || {};
-    const out = Object.create(null);
-    out["Factory default"] = null;
-    if (presetMap["Saved default"]) {
-      out["Saved default"] = savedMeta ? { ...savedMeta } : null;
-    }
-
-    for (const name of Object.keys(presetMap)) {
-      if (name === "Factory default" || name === "Saved default") continue;
-      out[name] = normalizePresetMeta(metaForGroup[name], {
-        stringMetaFormat: "array",
-      });
-    }
-    return out;
-  }, [PRESET_TUNING_META, systemId, strings, presetMap, savedMeta]);
-
-  const getPresetMeta = useCallback(
-    (name) => (name in presetMetaMap ? presetMetaMap[name] : null),
-    [presetMetaMap],
-  );
 
   const saveDefault = useCallback(
     (stringMeta, boardMeta) => {
@@ -191,10 +168,9 @@ export function useDefaultTuning({
       tuning,
       setTuning,
       presetMap,
-      presetMetaMap,
-      getPresetMeta,
       presetNames: Object.keys(presetMap),
       savedExists,
+      savedMeta,
       saveDefault,
       loadSavedDefault,
       resetFactoryDefault,
@@ -204,9 +180,8 @@ export function useDefaultTuning({
       tuning,
       setTuning,
       presetMap,
-      presetMetaMap,
-      getPresetMeta,
       savedExists,
+      savedMeta,
       saveDefault,
       loadSavedDefault,
       resetFactoryDefault,

--- a/src/hooks/usePresetMeta.js
+++ b/src/hooks/usePresetMeta.js
@@ -1,0 +1,110 @@
+import { useCallback, useMemo } from "react";
+import { normalizePresetMeta } from "@/lib/meta/meta";
+
+function normalizeBaseMeta({
+  presetNames,
+  presetMetaSource,
+  savedMeta,
+  systemId,
+  strings,
+}) {
+  const metaForGroup = presetMetaSource?.[systemId]?.[strings] || {};
+  const normalized = Object.create(null);
+
+  (Array.isArray(presetNames) ? presetNames : []).forEach((name) => {
+    if (name === "Saved default") {
+      const normalizedSaved = normalizePresetMeta(savedMeta, {
+        stringMetaFormat: "map",
+      });
+      if (normalizedSaved) normalized[name] = normalizedSaved;
+      return;
+    }
+
+    const meta = normalizePresetMeta(metaForGroup?.[name], {
+      stringMetaFormat: "map",
+    });
+    if (meta) normalized[name] = meta;
+  });
+
+  return normalized;
+}
+
+function normalizeCustomMeta(customTunings) {
+  if (!Array.isArray(customTunings) || !customTunings.length) return {};
+  const out = {};
+  for (const pack of customTunings) {
+    const name = typeof pack?.name === "string" ? pack.name : null;
+    if (!name) continue;
+    const meta = normalizePresetMeta(pack?.meta, { stringMetaFormat: "map" });
+    if (meta) out[name] = meta;
+  }
+  return out;
+}
+
+export function usePresetMeta({
+  presetNames = [],
+  presetMetaSource,
+  savedMeta,
+  customTunings,
+  systemId,
+  strings,
+  setStringMeta,
+  setBoardMeta,
+}) {
+  const basePresetMetaMap = useMemo(
+    () =>
+      normalizeBaseMeta({
+        presetNames,
+        presetMetaSource,
+        savedMeta,
+        systemId,
+        strings,
+      }),
+    [presetNames, presetMetaSource, savedMeta, systemId, strings],
+  );
+
+  const customPresetMetaMap = useMemo(
+    () => normalizeCustomMeta(customTunings),
+    [customTunings],
+  );
+
+  const mergedPresetMetaMap = useMemo(() => {
+    const merged = { ...basePresetMetaMap };
+    for (const [name, meta] of Object.entries(customPresetMetaMap)) {
+      merged[name] = meta;
+    }
+    return merged;
+  }, [basePresetMetaMap, customPresetMetaMap]);
+
+  const getPresetMeta = useCallback(
+    (name) => (name in mergedPresetMetaMap ? mergedPresetMetaMap[name] : null),
+    [mergedPresetMetaMap],
+  );
+
+  const applyPresetMeta = useCallback(
+    (name) => {
+      const meta = getPresetMeta(name);
+      if (meta?.stringMeta) setStringMeta?.(meta.stringMeta);
+      else setStringMeta?.(null);
+      if (meta?.board) setBoardMeta?.(meta.board);
+      else setBoardMeta?.(null);
+      return meta ?? null;
+    },
+    [getPresetMeta, setStringMeta, setBoardMeta],
+  );
+
+  const resetMetaForInstrumentChange = useCallback(() => {
+    setStringMeta?.(null);
+    setBoardMeta?.(null);
+  }, [setStringMeta, setBoardMeta]);
+
+  return useMemo(
+    () => ({
+      mergedPresetMetaMap,
+      getPresetMeta,
+      applyPresetMeta,
+      resetMetaForInstrumentChange,
+    }),
+    [mergedPresetMetaMap, getPresetMeta, applyPresetMeta, resetMetaForInstrumentChange],
+  );
+}


### PR DESCRIPTION
## Summary
- capture string-level fretStyle values during preset meta normalization and promote them to board meta
- retain board fretStyle when removing string-level duplicates to avoid losing preset styling

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fe95a5708330acf10bf494e392ac)