### PR TITLE
Refactor app layout into composable sections

### DIFF
--- a/src/components/Layout/AppLayout.jsx
+++ b/src/components/Layout/AppLayout.jsx
@@ -1,0 +1,17 @@
+export default function AppLayout({
+  header,
+  stage,
+  controls,
+  modals,
+  toaster,
+}) {
+  return (
+    <div className="tv-shell">
+      <header className="tv-shell__header">{header}</header>
+      <main className="tv-shell__main">{stage}</main>
+      <footer className="tv-shell__controls">{controls}</footer>
+      {modals}
+      {toaster}
+    </div>
+  );
+}

--- a/src/hooks/useDisplayState.js
+++ b/src/hooks/useDisplayState.js
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from "react";
+import { useFullscreen, useToggle } from "react-use";
+import { useDisplayPrefs } from "@/hooks/useDisplayPrefs";
+import { useTheme } from "@/hooks/useTheme";
+
+export function useDisplayState(defaults) {
+  const [displayPrefs, setDisplayPrefs, displaySetters] =
+    useDisplayPrefs(defaults);
+  const [theme, setTheme, themeMode] = useTheme();
+
+  const stageRef = useRef(null);
+  const [isFsRequested, toggleFs] = useToggle(false);
+  const isFs = useFullscreen(stageRef, isFsRequested, {
+    onClose: () => toggleFs(false),
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isFs) root.classList.add("is-fs");
+    else root.classList.remove("is-fs");
+    return () => root.classList.remove("is-fs");
+  }, [isFs]);
+
+  return {
+    displayPrefs,
+    setDisplayPrefs,
+    displaySetters,
+    theme,
+    setTheme,
+    themeMode,
+    stageRef,
+    isFs,
+    toggleFs,
+  };
+}

--- a/src/hooks/useInstrumentConfig.js
+++ b/src/hooks/useInstrumentConfig.js
@@ -1,0 +1,101 @@
+import { useCallback, useState } from "react";
+import { useFretsTouched } from "@/hooks/useFretsTouched";
+import { useInstrumentPrefs } from "@/hooks/useInstrumentPrefs";
+import { useDefaultTuning } from "@/hooks/useDefaultTuning";
+import { useStringsChange } from "@/hooks/useStringsChange";
+import { useDrawFrets } from "@/hooks/useDrawFrets";
+import { useCapo } from "@/hooks/useCapo";
+
+export function useInstrumentConfig({
+  system,
+  systemId,
+  stringsRange,
+  fretsRange,
+  factory,
+  presetMeta,
+  defaultTunings,
+  presetTunings,
+}) {
+  const { frets, setFrets, fretsTouched, setFretsUI, setFretsTouched } =
+    useFretsTouched(factory(system.divisions));
+
+  const { strings, setStrings, resetInstrumentPrefs, setFretsPref } =
+    useInstrumentPrefs({
+      frets,
+      fretsTouched,
+      setFrets,
+      setFretsUI,
+      setFretsTouched,
+      STR_MIN: stringsRange.min,
+      STR_MAX: stringsRange.max,
+      FRETS_MIN: fretsRange.min,
+      FRETS_MAX: fretsRange.max,
+      STR_FACTORY: factory,
+    });
+
+  const {
+    tuning,
+    setTuning,
+    presetMap,
+    presetMetaMap,
+    saveDefault,
+    savedExists,
+    defaultForCount,
+  } = useDefaultTuning({
+    systemId,
+    strings,
+    DEFAULT_TUNINGS: defaultTunings,
+    PRESET_TUNINGS: presetTunings,
+    PRESET_TUNING_META: presetMeta,
+  });
+
+  const [stringMeta, setStringMeta] = useState(null);
+  const [boardMeta, setBoardMeta] = useState(null);
+
+  const handleSaveDefault = useCallback(() => {
+    saveDefault(stringMeta, boardMeta);
+  }, [boardMeta, saveDefault, stringMeta]);
+
+  const handleStringsChange = useStringsChange({
+    setStrings,
+    setTuning,
+    defaultForCount,
+  });
+
+  const drawFrets = useDrawFrets({
+    baseFrets: frets,
+    divisions: system.divisions,
+    fretsTouched,
+    setFretsRaw: setFrets,
+  });
+
+  const capo = useCapo({
+    strings,
+    stringMeta,
+  });
+
+  return {
+    strings,
+    setStrings,
+    frets,
+    setFrets,
+    setFretsPref,
+    setFretsUI,
+    fretsTouched,
+    resetInstrumentPrefs,
+    tuning,
+    setTuning,
+    presetMap,
+    presetMetaMap,
+    savedExists,
+    defaultForCount,
+    stringMeta,
+    setStringMeta,
+    boardMeta,
+    setBoardMeta,
+    handleSaveDefault,
+    handleStringsChange,
+    drawFrets,
+    capo,
+  };
+}

--- a/src/hooks/useSystemState.js
+++ b/src/hooks/useSystemState.js
@@ -1,0 +1,42 @@
+import { useEffect, useMemo } from "react";
+import { useSystemPrefs } from "@/hooks/useSystemPrefs";
+import { useSystemNoteNames } from "@/hooks/useSystemNoteNames";
+
+export function useSystemState({
+  tunings,
+  defaultSystemId,
+  defaultRoot,
+  accidental,
+}) {
+  const { systemId, setSystemId, root, setRoot, ensureValidRoot } =
+    useSystemPrefs({
+      tunings,
+      defaultSystemId,
+      defaultRoot,
+    });
+
+  const system = useMemo(() => tunings[systemId], [systemId, tunings]);
+
+  const { pcFromName, nameForPc, sysNames } = useSystemNoteNames(
+    system,
+    accidental,
+  );
+
+  useEffect(() => {
+    ensureValidRoot(sysNames);
+  }, [ensureValidRoot, sysNames]);
+
+  const rootIx = pcFromName(root);
+
+  return {
+    systemId,
+    setSystemId,
+    system,
+    root,
+    setRoot,
+    pcFromName,
+    nameForPc,
+    sysNames,
+    rootIx,
+  };
+}


### PR DESCRIPTION
## Summary
- Extract system, display, and instrument concerns into dedicated hooks to simplify App state management
- Introduce a reusable AppLayout wrapper that composes header, stage, controls, modals, and toaster
- Restructure App.jsx to use the new hooks and layout, reducing prop drilling while keeping existing behaviors

## Testing
- pnpm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935832c0f2c8330b5ac20b0cd969540)